### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,9 @@ History
 Pending Release
 ---------------
 
-* New release notes here
+.. Insert new release notes below this line
+
+* Drop Python 2 support, only Python 3.4+ is supported now.
 
 1.0.0 (2016-04-22)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,14 @@ Install from pip with:
 
     pip install pytest-super-check
 
-Pytest will automatically find the plugin and use it when you run ``py.test``.
-Test discovery will then blow up if any subclasses of ``unittest.TestCase``
-are found that have ``setUp`` etc. methods that don't call ``super()``.
+Python 3.4+ supported.
+
+Pytest will automatically find and use the plugin. Test discovery will then
+blow up if any subclasses of ``unittest.TestCase`` are found that have
+``setUp`` etc. methods that don't call ``super()``.
 
 You can disable the plugin by passing the options ``-p no:super_check`` to
-``py.test``.
+``pytest``.
 
 Caveats
 -------

--- a/pytest_super_check.py
+++ b/pytest_super_check.py
@@ -1,11 +1,7 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import inspect
 from collections import defaultdict
 
 import pytest
-import six
 from _pytest.unittest import UnitTestCase
 
 __version__ = '1.0.0'
@@ -40,13 +36,12 @@ def pytest_collection_modifyitems(session, config, items):
             while hasattr(real_func, '__wrapped__'):
                 real_func = get_real_func(real_func.__wrapped__)
 
-            code = six.get_function_code(real_func)
-            if 'super' not in code.co_names:
+            if 'super' not in real_func.__code__.co_names:
                 errors[parent].append(name)
 
     if errors:
         raise pytest.UsageError(*[
-            error_msg(p, names) for p, names in six.iteritems(errors)
+            error_msg(p, names) for p, names in errors.items()
         ])
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,6 @@
 docutils
 flake8
-futures<3.2.0
 isort
-modernize
 multilint
 Pygments
 pytest
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,23 +6,16 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,20 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version('pytest_super_check.py')
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -34,9 +30,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'pytest',
-        'six',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="BSD",
     zip_safe=False,
     keywords='pytest, super, unittest, testcase',
@@ -49,9 +44,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,12 +1,4 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
-
-if six.PY3:
-    pytest_plugins = ['pytester']
-else:
-    pytest_plugins = [b'pytester']
+pytest_plugins = ['pytester']
 
 
 def test_it_does_not_complain_when_everything_supers_correctly(testdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-codestyle,
-    py{27,36}
+    py3,
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -10,11 +10,6 @@ install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = pytest -p no:restrict {posargs}
 
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building