### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ pytest-super-check
 .. image:: https://img.shields.io/pypi/v/pytest-super-check.svg
         :target: https://pypi.python.org/pypi/pytest-super-check
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 Pytest plugin to check your TestCase classes call super in setUp, tearDown,
 etc.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/pytest_super_check.py
+++ b/pytest_super_check.py
@@ -4,24 +4,26 @@ from collections import defaultdict
 import pytest
 from _pytest.unittest import UnitTestCase
 
-__version__ = '2.0.0'
+__version__ = "2.0.0"
 
 
 def pytest_collection_modifyitems(session, config, items):
     errors = defaultdict(list)
 
     for item in items:
-        parent = getattr(item, 'parent', None)
-        if (
-            parent is None or
-            not isinstance(parent, UnitTestCase) or
-            parent in errors
-        ):
+        parent = getattr(item, "parent", None)
+        if parent is None or not isinstance(parent, UnitTestCase) or parent in errors:
             continue
 
         klass = parent.cls
 
-        for name in ('setUpClass', 'setUpTestData', 'setUp', 'tearDown', 'tearDownClass'):
+        for name in (
+            "setUpClass",
+            "setUpTestData",
+            "setUp",
+            "tearDown",
+            "tearDownClass",
+        ):
             try:
                 klass.__dict__[name]
             except KeyError:
@@ -33,16 +35,14 @@ def pytest_collection_modifyitems(session, config, items):
             real_func = get_real_func(func)
 
             # Unwrap any decorators, we only care about inspecting the innermost
-            while hasattr(real_func, '__wrapped__'):
+            while hasattr(real_func, "__wrapped__"):
                 real_func = get_real_func(real_func.__wrapped__)
 
-            if 'super' not in real_func.__code__.co_names:
+            if "super" not in real_func.__code__.co_names:
                 errors[parent].append(name)
 
     if errors:
-        raise pytest.UsageError(*[
-            error_msg(p, names) for p, names in errors.items()
-        ])
+        raise pytest.UsageError(*[error_msg(p, names) for p, names in errors.items()])
 
 
 def get_real_func(func):
@@ -60,7 +60,6 @@ def get_real_func(func):
 
 
 def error_msg(parent, names):
-    return '{parent_id} does not call super() in {names}'.format(
-        parent_id=parent.nodeid,
-        names=', '.join(names),
+    return "{parent_id} does not call super() in {names}".format(
+        parent_id=parent.nodeid, names=", ".join(names)
     )

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,6 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -107,6 +121,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
+flake8-bugbear
 isort
 multilint
 Pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,15 @@
 [flake8]
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
-multi_line_output = 5
+include_trailing_comma = True
+force_grid_wrap = 0
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE
@@ -11,4 +17,4 @@ license_file = LICENSE
 [tool:multilint]
 paths = pytest_super_check.py
         setup.py
-        tests
+        test_pytest_super_check.py

--- a/setup.py
+++ b/setup.py
@@ -4,50 +4,49 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('pytest_super_check.py')
+version = get_version("pytest_super_check.py")
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='pytest-super-check',
+    name="pytest-super-check",
     version=version,
-    description='Pytest plugin to check your TestCase classes call super in setUp, tearDown, etc.',
-    long_description=readme + '\n\n' + history,
+    description=(
+        "Pytest plugin to check your TestCase classes call super in setUp, "
+        + "tearDown, etc."
+    ),
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/pytest-super-check',
-    py_modules=['pytest_super_check'],
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/pytest-super-check",
+    py_modules=["pytest_super_check"],
     include_package_data=True,
-    install_requires=[
-        'pytest',
-    ],
-    python_requires='>=3.5',
+    install_requires=["pytest"],
+    python_requires=">=3.5",
     license="BSD",
     zip_safe=False,
-    keywords='pytest, super, unittest, testcase',
-    entry_points={
-        'pytest11': ['super_check = pytest_super_check'],
-    },
+    keywords="pytest, super, unittest, testcase",
+    entry_points={"pytest11": ["super_check = pytest_super_check"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_pytest_super_check.py
+++ b/test_pytest_super_check.py
@@ -1,4 +1,4 @@
-pytest_plugins = ['pytester']
+pytest_plugins = ["pytester"]
 
 
 def test_it_does_not_complain_when_everything_supers_correctly(testdir):
@@ -52,9 +52,9 @@ def test_it_complains_when_a_case_does_not_super_in_setUp(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in setUp'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in setUp"]
+    )
 
 
 def test_it_complains_when_a_case_does_not_super_in_tearDown(testdir):
@@ -74,9 +74,9 @@ def test_it_complains_when_a_case_does_not_super_in_tearDown(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in tearDown'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in tearDown"]
+    )
 
 
 def test_it_complains_when_a_case_does_not_super_in_setUpClass(testdir):
@@ -97,9 +97,9 @@ def test_it_complains_when_a_case_does_not_super_in_setUpClass(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in setUpClass'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in setUpClass"]
+    )
 
 
 def test_it_complains_when_a_case_does_not_super_in_setUpTestData(testdir):
@@ -125,9 +125,9 @@ def test_it_complains_when_a_case_does_not_super_in_setUpTestData(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in setUpTestData'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in setUpTestData"]
+    )
 
 
 def test_it_complains_when_a_case_does_not_super_in_tearDownClass(testdir):
@@ -148,9 +148,9 @@ def test_it_complains_when_a_case_does_not_super_in_tearDownClass(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in tearDownClass'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in tearDownClass"]
+    )
 
 
 def test_it_complains_when_a_case_does_not_super_in_setUp_and_setUpClass(testdir):
@@ -174,9 +174,9 @@ def test_it_complains_when_a_case_does_not_super_in_setUp_and_setUpClass(testdir
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in setUpClass, setUp'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in setUpClass, setUp"]
+    )
 
 
 def test_it_does_not_complain_when_a_decorator_is_used_but_super_is_called(testdir):
@@ -235,6 +235,6 @@ def test_it_complains_when_a_decorator_is_used_and_super_is_not_called(testdir):
     )
     out = testdir.runpytest()
     assert out.ret > 0
-    out.stderr.fnmatch_lines([
-        'ERROR: test_one.py::MyTests does not call super() in setUp'
-    ])
+    out.stderr.fnmatch_lines(
+        ["ERROR: test_one.py::MyTests does not call super() in setUp"]
+    )


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge