### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/pytest_super_check/__init__.py
+++ b/src/pytest_super_check/__init__.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import inspect
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 import pytest
 from _pytest.config import Config


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
